### PR TITLE
Fixed login

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -37,11 +37,8 @@ function Login() {
 	const onChange = (event: ChangeEvent<HTMLInputElement>) => {
 		const { name, value } = event.target;
 
-		if (name === "username") {
-			usernameRef.current?.setCustomValidity("");
-		} else {
-			passwordRef.current?.setCustomValidity("");
-		}
+		usernameRef.current?.setCustomValidity("");
+		passwordRef.current?.setCustomValidity("");
 
 		setForm((prev) => ({ ...prev, [name]: value }));
 	};


### PR DESCRIPTION
When logging in with a **Bad Request** the input `setCustomValidity("Invalid username or password.")` is still present for either of the input is updated.